### PR TITLE
added password gate

### DIFF
--- a/src/app/streaming/[seasonId]/[concertId]/page.tsx
+++ b/src/app/streaming/[seasonId]/[concertId]/page.tsx
@@ -5,6 +5,7 @@ import { removeSeasonNumberFromConcertId } from "@/utils/textFormat";
 import { notFound } from "next/navigation";
 
 // Static import — avoids duplicate imports in both functions
+import PasswordGate from "@/components/atoms/PasswordGate";
 import liveData from "@/data/live-data.json";
 
 export async function generateStaticParams() {
@@ -45,16 +46,18 @@ export default async function WatchConcertPage({
   }
 
   return (
-    <SectionEmpty>
-      <h1 className="text-4xl font-bold mb-4">{concertData.title}</h1>
-      <div className="streaming-container bg-gray-50 w-full aspect-video flex justify-center items-center">
-        <VideoWithCustomThumbnail
-          thumbnail={`/graphics/${seasonId}/streaming-thumbnails/${concertData.concertId}.webp`}
-          icon={<LogoIcon color="var(--water-600)" />}
-          youtubeUrl={concertData.youTubeUrl || ""}
-        />
-      </div>
-      <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(concertData, null, 2)}</pre>
-    </SectionEmpty>
+    <PasswordGate>
+      <SectionEmpty>
+        <h1 className="text-4xl font-bold mb-4">{concertData.title}</h1>
+        <div className="streaming-container bg-gray-50 w-full aspect-video flex justify-center items-center">
+          <VideoWithCustomThumbnail
+            thumbnail={`/graphics/${seasonId}/streaming-thumbnails/${concertData.concertId}.webp`}
+            icon={<LogoIcon color="var(--water-600)" />}
+            youtubeUrl={concertData.youTubeUrl || ""}
+          />
+        </div>
+        <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(concertData, null, 2)}</pre>
+      </SectionEmpty>
+    </PasswordGate>
   );
 }

--- a/src/app/streaming/[seasonId]/season-pass/page.tsx
+++ b/src/app/streaming/[seasonId]/season-pass/page.tsx
@@ -1,0 +1,48 @@
+import { LogoIcon } from "@/assets/logoIcon";
+import { VideoWithCustomThumbnail } from "@/components/organisms";
+import { SectionEmpty } from "@/components/sections";
+import { notFound } from "next/navigation";
+
+// Static import — avoids duplicate imports in both functions
+import PasswordGate from "@/components/atoms/PasswordGate";
+import liveData from "@/data/live-data.json";
+
+export async function generateStaticParams() {
+  return liveData
+    .filter((season) => season.seasonStreamingPageUrl) // Only seasons that have streaming pages
+    .map((season) => ({
+      seasonId: season.seasonId,
+    }));
+}
+
+export default async function SeasonPassPage({ params }: { params: Promise<{ seasonId: string }> }) {
+  const { seasonId } = await params;
+
+  // Find the season data that matches both the seasonId and the current URL path
+  const currentUrl = `/streaming/${seasonId}/season-pass`;
+  const seasonData = liveData.find(
+    (season) => season.seasonId === seasonId && season.seasonStreamingPageUrl === currentUrl
+  );
+
+  if (!seasonData) {
+    notFound();
+  }
+
+  return (
+    <PasswordGate>
+      <SectionEmpty>
+        <h1 className="text-4xl font-bold mb-4">
+          Season {seasonData.seasonId.toUpperCase()} Pass - {seasonData.year}
+        </h1>
+        <div className="streaming-container bg-gray-50 w-full aspect-video flex justify-center items-center">
+          <VideoWithCustomThumbnail
+            thumbnail={`/graphics/${seasonId}/streaming-thumbnails/season-pass.webp`}
+            icon={<LogoIcon color="var(--water-600)" />}
+            youtubeUrl={seasonData.youTubeUrl || ""}
+          />
+        </div>
+        <pre className="bg-gray-100 p-4 rounded overflow-auto">{JSON.stringify(seasonData, null, 2)}</pre>
+      </SectionEmpty>
+    </PasswordGate>
+  );
+}

--- a/src/components/atoms/PasswordGate.tsx
+++ b/src/components/atoms/PasswordGate.tsx
@@ -48,7 +48,6 @@ export default function PasswordGate({ children }: { children: React.ReactNode }
   };
 
   if (!correctPassword) {
-    console.warn(`No password found for ${pathname}`);
     return <>{children}</>; // fallback to open page if not in data
   }
 

--- a/src/components/atoms/PasswordGate.tsx
+++ b/src/components/atoms/PasswordGate.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import liveData from "@/data/live-data.json";
+import concerts from "@/data/serve/concerts.json";
+import seasons from "@/data/serve/seasons.json";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Button } from "./Button";
+
+export default function PasswordGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const [unlocked, setUnlocked] = useState(false);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [wrongPassword, setWrongPassword] = useState(false);
+
+  // 1. Try to find matching concert
+  const concertMatch = concerts.find((c) => c.streamingPageUrl === pathname);
+  // 2. Try to find matching season from the serve data
+  const seasonMatch = seasons.find((s) => s.seasonStreamingPageUrl === pathname);
+  // 3. Try to find matching season from the live data (for season-pass pages)
+  const liveSeasonMatch = liveData.find((s) => s.seasonStreamingPageUrl === pathname);
+
+  const correctPassword =
+    concertMatch?.streamingPagePassword ||
+    seasonMatch?.seasonStreamingPagePassword ||
+    liveSeasonMatch?.seasonStreamingPagePassword ||
+    "";
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(`unlocked-${pathname}`);
+    if (stored === "true") setUnlocked(true);
+  }, [pathname]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setTimeout(() => {
+      if (input === correctPassword) {
+        sessionStorage.setItem(`unlocked-${pathname}`, "true");
+        setUnlocked(true);
+        setLoading(false);
+      } else {
+        setLoading(false);
+        setWrongPassword(true);
+      }
+    }, 400);
+  };
+
+  if (!correctPassword) {
+    console.warn(`No password found for ${pathname}`);
+    return <>{children}</>; // fallback to open page if not in data
+  }
+
+  if (unlocked) return <>{children}</>;
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center min-h-screen p-4 delay-100 ${wrongPassword ? "animation-smh" : ""}`}
+    >
+      <h1 className="mb-4 text-xl font-bold">Enter Password</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input type="password" value={input} onChange={(e) => setInput(e.target.value)} className="border p-2" />
+        <Button type="submit" variant="filled" size="md" color="sand" disabled={loading} loading={loading}>
+          {loading ? "Unlocking..." : "Unlock"}
+        </Button>
+        <div
+          className={` ${wrongPassword ? "opacity-100" : "opacity-0"} bg-red-600 px-s py-half text-white text-center text-sm kode-mono mt-s`}
+        >
+          Wrong password
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/data/live-data.json
+++ b/src/data/live-data.json
@@ -21,8 +21,8 @@
       }
     },
     "youTubeUrl": "",
-    "seasonStreamingPagePassword": "",
-    "seasonStreamingPageUrl": ""
+    "seasonStreamingPagePassword": "password",
+    "seasonStreamingPageUrl": "/streaming/s10/season-pass"
   },
   {
     "seasonId": "s09",
@@ -47,8 +47,8 @@
       }
     },
     "youTubeUrl": "",
-    "seasonStreamingPagePassword": "",
-    "seasonStreamingPageUrl": ""
+    "seasonStreamingPagePassword": "password",
+    "seasonStreamingPageUrl": "/streaming/s09/season-pass"
   },
   {
     "seasonId": "s08",

--- a/src/data/serve/concerts.json
+++ b/src/data/serve/concerts.json
@@ -18,7 +18,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -64,7 +64,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -106,7 +106,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -152,7 +152,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -198,7 +198,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -232,7 +232,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -270,7 +270,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -316,7 +316,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -346,7 +346,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -376,7 +376,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -418,7 +418,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -456,7 +456,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -490,7 +490,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -529,7 +529,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -571,7 +571,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -617,7 +617,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -647,7 +647,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -689,7 +689,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -731,7 +731,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -771,7 +771,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -813,7 +813,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -855,7 +855,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -897,7 +897,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -943,7 +943,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -977,7 +977,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1026,7 +1026,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1076,7 +1076,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1118,7 +1118,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1152,7 +1152,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1191,7 +1191,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1233,7 +1233,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "The Gardener Foundation",
     "program": [
@@ -1273,7 +1273,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "Sarasota County Tourist Development Tax revenues, Susan Robinson",
     "program": [
@@ -1304,7 +1304,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "Robert and Debbie Hendel",
     "program": [
@@ -1347,7 +1347,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "Eric Dean and Pat Michelsen",
     "program": [
@@ -1385,7 +1385,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1429,7 +1429,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1475,7 +1475,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "Susan Robinson, Robert & Deborah Hendel, Ben & Gigi Huberman",
     "program": [
@@ -1513,7 +1513,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "program": [
       {
@@ -1546,7 +1546,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "Pamela MacFarlane Palmer",
     "program": [
@@ -1591,7 +1591,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "The Gardener Foundation",
     "program": [
@@ -1625,7 +1625,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1683,7 +1683,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1725,7 +1725,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1795,7 +1795,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1841,7 +1841,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1887,7 +1887,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1917,7 +1917,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1947,7 +1947,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -1985,7 +1985,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -2015,7 +2015,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -2049,7 +2049,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -2079,7 +2079,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -2117,7 +2117,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -2147,7 +2147,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "",
     "sponsors": "",
     "program": [
@@ -2181,7 +2181,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2024-09-23-night-reflected",
     "sponsors": "",
     "program": [
@@ -2227,7 +2227,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2024-10-07-suncoast-fellowship-concert",
     "sponsors": "",
     "program": [
@@ -2289,7 +2289,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2024-11-25-ives-and-schoenberg-at-150",
     "sponsors": "",
     "program": [
@@ -2323,7 +2323,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2025-01-13-visions-and-miracles",
     "sponsors": "",
     "program": [
@@ -2369,7 +2369,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2025-02-17-truth-and-mayhem",
     "sponsors": "",
     "program": [
@@ -2411,7 +2411,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2025-03-17-critical-moments",
     "sponsors": "",
     "program": [
@@ -2457,7 +2457,7 @@
         "url": ""
       }
     },
-    "streamingPagePassword": "",
+    "streamingPagePassword": "PLACEHOLDER",
     "streamingPageUrl": "/streaming/s09/2025-05-12-jagden-und-formen",
     "sponsors": "",
     "program": [

--- a/src/styles/_animations.css
+++ b/src/styles/_animations.css
@@ -129,3 +129,25 @@
     text-orientation: mixed;
   }
 }
+
+@keyframes smh {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  10%,
+  30%,
+  50%,
+  70% {
+    transform: translateX(-10px);
+  }
+  20%,
+  40%,
+  60%,
+  80% {
+    transform: translateX(10px);
+  }
+}
+.animation-smh {
+  animation: smh 0.6s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}


### PR DESCRIPTION
This pull request introduces a password protection feature for streaming concert and season pass pages. The main changes include implementing a reusable password gate component, updating page files to use this gate, and setting up password fields in the relevant data sources.

**Feature: Password Protection for Streaming Pages**

* Added a new `PasswordGate` React component in `src/components/atoms/PasswordGate.tsx` that checks for a password associated with the current streaming page URL and prompts the user to enter it before granting access. It supports both concert and season pass pages, using data from multiple sources.
* Updated `src/app/streaming/[seasonId]/[concertId]/page.tsx` and created `src/app/streaming/[seasonId]/season-pass/page.tsx` to wrap their content with the `PasswordGate` component, enforcing password protection on these pages. ([src/app/streaming/[seasonId]/[concertId]/page.tsxR8](diffhunk://#diff-3b9fdacbbea60876f702f1314e51bbf4a6ecbf17588b5950fa81931e7393776dR8), [src/app/streaming/[seasonId]/[concertId]/page.tsxR49](diffhunk://#diff-3b9fdacbbea60876f702f1314e51bbf4a6ecbf17588b5950fa81931e7393776dR49), [src/app/streaming/[seasonId]/[concertId]/page.tsxR61](diffhunk://#diff-3b9fdacbbea60876f702f1314e51bbf4a6ecbf17588b5950fa81931e7393776dR61), [src/app/streaming/[seasonId]/season-pass/page.tsxR1-R48](diffhunk://#diff-be5dd4cd0d253ef03a3971888b654012ce1fefbf4551a54e0d2789e659ca64aeR1-R48))

**Data Updates: Password Fields**

* Set the `seasonStreamingPagePassword` and `seasonStreamingPageUrl` fields for seasons S09 and S10 in `src/data/live-data.json`, enabling password protection for their season pass pages. [[1]](diffhunk://#diff-6eee75fb33f25604fafa896dfbcc0d7388879c2e8903b0edb5ca129aecc1fa10L24-R25) [[2]](diffhunk://#diff-6eee75fb33f25604fafa896dfbcc0d7388879c2e8903b0edb5ca129aecc1fa10L50-R51)
* Populated the `streamingPagePassword` field with a placeholder value for all concerts in `src/data/serve/concerts.json`, preparing these pages for password protection. [[1]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L21-R21) [[2]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L67-R67) [[3]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L109-R109) [[4]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L155-R155) [[5]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L201-R201) [[6]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L235-R235) [[7]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L273-R273) [[8]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L319-R319) [[9]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L349-R349) [[10]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L379-R379) [[11]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L421-R421) [[12]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L459-R459) [[13]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L493-R493) [[14]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L532-R532) [[15]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L574-R574) [[16]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L620-R620) [[17]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L650-R650) [[18]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L692-R692) [[19]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L734-R734) [[20]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L774-R774) [[21]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L816-R816) [[22]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L858-R858) [[23]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L900-R900) [[24]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L946-R946) [[25]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L980-R980) [[26]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L1029-R1029) [[27]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L1079-R1079) [[28]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L1121-R1121) [[29]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L1155-R1155) [[30]](diffhunk://#diff-926a167d06651209e1dbacd351b0eabb9f2dafd0c08fccbb28c00850671ebd14L1194-R1194)

These changes ensure that only users with the correct password can view protected streaming content, and the password gate logic is centralized for maintainability.